### PR TITLE
Acceleration constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ controller_server:
 mpc_optimization_server:
   ros__parameters:
     # Acceleration limits
-    acc_x_limit: 2.5
-    acc_y_limit: 2.5
-    acc_theta_limit: 3.0
+    acc_x_limit: 1.5
+    acc_y_limit: 1.5
+    acc_theta_limit: 0.8
     
     # Velocity limits (min)
     min_vel_x: -0.7
@@ -77,8 +77,8 @@ mpc_optimization_server:
     w_costmap: 0.05                    # Costmap traversal weight 
     
     # Adaptive behavior parameters
-    sharp_turn_threshold: 0.52         # Turn angle threshold (radians) for tight lookahead activation (~30 degrees)
-    tight_lookahead_dist_threshold: 1.0  # Distance to obstacles (m) for adaptive orientation control
+    sharp_turn_threshold: 0.8         # Turn angle threshold (radians) for tight lookahead activation (~30 degrees)
+    tight_lookahead_dist_threshold: 0.5  # Distance to obstacles (m) for adaptive orientation control
     
     # Optimizer parameters
     waiting_time: 3.0                  # Waiting time before retry after obstacle collision

--- a/neo_mpc_planner2/mpc_optimization_server.py
+++ b/neo_mpc_planner2/mpc_optimization_server.py
@@ -151,9 +151,14 @@ class MpcOptimizationServer(Node):
 			self.bnds.append(b_x_vel)
 			self.bnds.append(b_y_vel)
 			self.bnds.append(b_rot)
+			
 			# Velocity magnitude constraint
 			self.cons.append({'type': 'ineq', 'fun': partial(self.f_constraint, index = i)})
-			# CBF is now a soft constraint (penalty in objective function)
+			
+			# Acceleration constraints for smooth motion
+			# self.cons.append({'type': 'ineq', 'fun': partial(self.acc_x_constraint, index = i)})
+			# self.cons.append({'type': 'ineq', 'fun': partial(self.acc_y_constraint, index = i)})
+			# self.cons.append({'type': 'ineq', 'fun': partial(self.acc_theta_constraint, index = i)})
 			
 		self.initial_guess = np.zeros(self.no_ctrl_steps * 3)
 		self.dt  = self.prediction_horizon /self.no_ctrl_steps
@@ -178,6 +183,40 @@ class MpcOptimizationServer(Node):
 
 	def f_constraint(self, initial, index):
 		return  self.max_vel_trans - (np.sqrt((initial[0 + index * 3]) * (initial[0 + index * 3]) +(initial[1 + index * 3]) * (initial[1 + index * 3])))   
+
+	# Acceleration constraint functions
+	def acc_x_constraint(self, cmd_vel, index):
+		"""Ensure vx doesn't exceed acceleration limits"""
+		if index == 0:
+			# First step: compare to last control
+			delta_v = cmd_vel[0] - self.last_control[0]
+		else:
+			# Subsequent steps: compare to previous step
+			delta_v = cmd_vel[0 + index * 3] - cmd_vel[0 + (index-1) * 3]
+		
+		max_delta = self.acc_x_limit * self.dt
+		# Return positive value when constraint is satisfied
+		return max_delta - abs(delta_v)
+	
+	def acc_y_constraint(self, cmd_vel, index):
+		"""Ensure vy doesn't exceed acceleration limits"""
+		if index == 0:
+			delta_v = cmd_vel[1] - self.last_control[1]
+		else:
+			delta_v = cmd_vel[1 + index * 3] - cmd_vel[1 + (index-1) * 3]
+		
+		max_delta = self.acc_y_limit * self.dt
+		return max_delta - abs(delta_v)
+	
+	def acc_theta_constraint(self, cmd_vel, index):
+		"""Ensure angular velocity doesn't exceed acceleration limits"""
+		if index == 0:
+			delta_v = cmd_vel[2] - self.last_control[2]
+		else:
+			delta_v = cmd_vel[2 + index * 3] - cmd_vel[2 + (index-1) * 3]
+		
+		max_delta = self.acc_theta_limit * self.dt
+		return max_delta - abs(delta_v)   
 
 	def euler_from_quaternion(self, x, y, z, w):
 		t0 = +2.0 * (w * x + y * z)


### PR DESCRIPTION
Right now hard acceleration constraints are disabled. For now using the software limit to accelerate the robot. Since the update frequency is less than the control horizon, it doesn't matter if we warms start with the predictions to which the acceleration limits were applied. 